### PR TITLE
Develop

### DIFF
--- a/R/DAISIE_ML1.R
+++ b/R/DAISIE_ML1.R
@@ -162,13 +162,17 @@ DAISIE_ML1 = function(
     idparseq = c(2,4)
   }
   idpars = sort(c(idparsopt,idparsfix,idparsnoshift,idparseq))
+  if(all(idparsopt <= 5))
+  {
+    idpars = c(idpars, 11)
+  }
   missnumspec = unlist(lapply(datalist,function(list) {list$missing_species}))
   if(sum(missnumspec) > (res - 1))
   {
     cat("The number of missing species is too large relative to the resolution of the ODE.\n")
     return(out2err)
   }
-  if((prod(idpars == (1:10)) != 1) || (length(initparsopt) != length(idparsopt)) || (length(parsfix) != length(idparsfix)))
+  if((prod(idpars == (1:11)) != 1) || (length(initparsopt) != length(idparsopt)) || (length(parsfix) != length(idparsfix)))
   {
     cat("The parameters to be optimized and/or fixed are incoherent.\n")
     return(out2err)

--- a/tests/testthat/test-DAISIE_ML_2type.R
+++ b/tests/testthat/test-DAISIE_ML_2type.R
@@ -1,0 +1,19 @@
+test_that("The parameter choice for 2type DAISIE_ML works", {
+  Galapagos_datalist_2types <- NULL
+  rm(Galapagos_datalist_2types)
+  utils::data(Galapagos_datalist_2types, package = "DAISIE")
+  set.seed(1)
+  # MLE and high tolerance for speed-up
+  Fit <- DAISIE_ML(
+    datalist = Galapagos_datalist_2types,
+    initparsopt = c(2.183336,2.517413,0.009909,1.080458,1.316296,0.001416),
+    idparsopt = c(1,2,4,5,7,11),
+    parsfix = c(Inf,Inf),
+    idparsfix = c(3,8),
+    idparsnoshift = c(6,9,10),
+    res = 30, 
+    tol = c(1, 1, 1),
+    maxiter = 30
+  )
+  testthat::expect_equal(Fit$loglik, -74.7557, tol = 1E-3)
+})


### PR DESCRIPTION
Hi Rampal,

DAISIE_ML is not starting to perform the maximum likelihood search for datalists with clades of two different types because the initial parameter check fails. 
This is because there are 11 parameters but DAISIE_ML checks for 10 (DAISIE_SR_ML tests correctly for 11). I also added a test for the fix.

Cheers, Torsten