### PR TITLE
Document stac = 0 in some sim functions

### DIFF
--- a/R/DAISIE_SR_sim.R
+++ b/R/DAISIE_SR_sim.R
@@ -1,17 +1,17 @@
 #' @title Simulate islands with given parameters.
 #' @description This function simulates islands with given cladogenesis, extinction, Kprime,
-#' immigration and anagenesis parameters that shift at some time. 
+#' immigration and anagenesis parameters that shift at some time.
 #' Runs the function with clade-specific
 #' carrying capacity, where diversity-dependence operates only within single
 #' clades, i.e. only among species originating from the same mainland
 #' colonist.
-#' 
+#'
 #' Returns R list object that contains the simulated islands.
-#' 
+#'
 #' @param time Length of the simulation in time units. For example, if an
 #' island is know to be 4 million years old, setting time = 4 will simulate
 #' entire life span of the island; setting time = 2 will stop the simulation at
-#' the mid-life of the island. 
+#' the mid-life of the island.
 #' @param M The size of the mainland pool, i.e the number of species that can
 #' potentially colonize the island
 #' @param pars Contains the model parameters: \cr \cr \code{pars[1]}
@@ -27,7 +27,7 @@
 #' (immigration rate)  after the shift \cr \code{pars[10]} corresponds to
 #' lambda^a (anagenesis rate) after the shift \cr \code{pars[11]} corresponds to
 #' the time of shift. This is defined as time before the end of the simulation. For example,
-#' setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and 
+#' setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and
 #' with pars[6:10] from 1.5 to 0.
 #' @param replicates Number of island replicates to be simulated.
 #' @param sample_freq Specifies the number of units time should be divided by
@@ -52,7 +52,7 @@
 #' - the number of mainland lineages that are not present on the island \cr
 #' \code{$stt_all} - STT table for all species on the island (nI - number of
 #' non-endemic species; nA - number of anagenetic species, nC - number of
-#' cladogenetic species, present - number of independent colonisations present)\cr  
+#' cladogenetic species, present - number of independent colonisations present)\cr
 #' The subsequent elements of the list each contain information on a single
 #' colonist lineage on the island and has 4 components:\cr
 #' \code{$branching_times} - island age and stem age of the population/species
@@ -66,14 +66,18 @@
 #' - whether the colonist belongs to type 1 or type 2 \cr
 #' @author Luis Valente, Albert Phillimore, and Torsten Hauffe
 #' @seealso \code{\link{DAISIE_plot_sims}}
-#' @references Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted). 
+#' @references Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted).
 #' Lake expansion increases equilibrium diversity via the target effect of
 #' island biogeography
+#' @note This function produces an extra element per replicate when the
+#' island is empty at time = 0. Functionally this has no effect on the
+#' simulations, but care should be taken if using the length of objects to count
+#' the number of species present on the island.
 #' @keywords models
 #' @examples
-#' # Simulate 15 islands for 4 million years with a shift in immigration rate 
-#' # at 0.195 Ma, and plot the species-through-time plot. Pool size 296. 
-#' 
+#' # Simulate 15 islands for 4 million years with a shift in immigration rate
+#' # at 0.195 Ma, and plot the species-through-time plot. Pool size 296.
+#'
 #' pars_before_shift = c(0.079, 0.973, Inf, 0.136, 0.413)
 #' pars_after_shift = c(0.079, 0.973, Inf, 0.652, 0.413)
 #' tshift = 0.195
@@ -83,17 +87,17 @@
 #'    pars = c(pars_before_shift, pars_after_shift, tshift),
 #'    replicates = 15
 #'  )
-#' 
+#'
 #' @export DAISIE_SR_sim
 
-DAISIE_SR_sim <- function(time, 
-                          M, 
-                          pars, 
-                          replicates, 
-                          sample_freq = 25, 
-                          plot_sims = TRUE, 
-                          ddep = 11, 
-                          ...) 
+DAISIE_SR_sim <- function(time,
+                          M,
+                          pars,
+                          replicates,
+                          sample_freq = 25,
+                          plot_sims = TRUE,
+                          ddep = 11,
+                          ...)
 {
   if (length(pars) != 11)
   {
@@ -112,7 +116,7 @@ DAISIE_SR_sim <- function(time,
     island_replicates[[rep]] = full_list
     print(paste("Island replicate ", rep, sep = ""))
   }
-  island_replicates = DAISIE_format_CS(island_replicates = island_replicates, 
+  island_replicates = DAISIE_format_CS(island_replicates = island_replicates,
                                        time = time, M = M, sample_freq = sample_freq)
   if (plot_sims == TRUE)
   {

--- a/R/DAISIE_sim_core_1_4.R
+++ b/R/DAISIE_sim_core_1_4.R
@@ -15,6 +15,10 @@
 #'   \item{[4]: immigration rate}
 #'   \item{[5]: anagenesis rate}
 #' }
+#' @note This function produces an extra element per replicate when the
+#' island is empty at time = 0. Functionally this has no effect on the
+#' simulations, but care should be taken if using the length of objects to count
+#' the number of species present on the island.
 DAISIE_sim_core_1_4 = function(time, mainland_n, pars)
 {
   lac = pars[1]

--- a/R/DAISIE_sim_core_1_4a.R
+++ b/R/DAISIE_sim_core_1_4a.R
@@ -15,6 +15,10 @@
 #'   \item{[4]: immigration rate}
 #'   \item{[5]: anagenesis rate}
 #' }
+#' @note This function produces an extra element per replicate when the
+#' island is empty at time = 0. Functionally this has no effect on the
+#' simulations, but care should be taken if using the length of objects to count
+#' the number of species present on the island.
 DAISIE_sim_core_1_4a <- function(time, mainland_n, pars)
 {
   lac = pars[1]

--- a/R/DAISIE_sim_core_1_5.R
+++ b/R/DAISIE_sim_core_1_5.R
@@ -1,3 +1,7 @@
+# This function produces an extra element per replicate when the
+# island is empty at time = 0. Functionally this has no effect on the
+# simulations, but care should be taken if using the length of objects to count
+# the number of species present on the island.
 DAISIE_sim_core_1_5 <- function(time,mainland_n,pars)
 {
   totaltime <- time

--- a/man/DAISIE_SR_sim.Rd
+++ b/man/DAISIE_SR_sim.Rd
@@ -37,7 +37,7 @@ K=Inf for non-diversity dependence. \cr \code{pars[9]} corresponds to gamma
 (immigration rate)  after the shift \cr \code{pars[10]} corresponds to
 lambda^a (anagenesis rate) after the shift \cr \code{pars[11]} corresponds to
 the time of shift. This is defined as time before the end of the simulation. For example,
-setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and 
+setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and
 with pars[6:10] from 1.5 to 0.}
 
 \item{replicates}{Number of island replicates to be simulated.}
@@ -69,7 +69,7 @@ components: \cr \code{$island_age} - the island age \cr Then, we have:\cr \code{
 - the number of mainland lineages that are not present on the island \cr
 \code{$stt_all} - STT table for all species on the island (nI - number of
 non-endemic species; nA - number of anagenetic species, nC - number of
-cladogenetic species, present - number of independent colonisations present)\cr  
+cladogenetic species, present - number of independent colonisations present)\cr
 The subsequent elements of the list each contain information on a single
 colonist lineage on the island and has 4 components:\cr
 \code{$branching_times} - island age and stem age of the population/species
@@ -84,7 +84,7 @@ particular clade (only applicable for endemic clades) \cr \code{$type_1or2}
 }
 \description{
 This function simulates islands with given cladogenesis, extinction, Kprime,
-immigration and anagenesis parameters that shift at some time. 
+immigration and anagenesis parameters that shift at some time.
 Runs the function with clade-specific
 carrying capacity, where diversity-dependence operates only within single
 clades, i.e. only among species originating from the same mainland
@@ -92,9 +92,15 @@ colonist.
 
 Returns R list object that contains the simulated islands.
 }
+\note{
+This function produces an extra element per replicate when the
+island is empty at time = 0. Functionally this has no effect on the
+simulations, but care should be taken if using the length of objects to count
+the number of species present on the island.
+}
 \examples{
-# Simulate 15 islands for 4 million years with a shift in immigration rate 
-# at 0.195 Ma, and plot the species-through-time plot. Pool size 296. 
+# Simulate 15 islands for 4 million years with a shift in immigration rate
+# at 0.195 Ma, and plot the species-through-time plot. Pool size 296.
 
 pars_before_shift = c(0.079, 0.973, Inf, 0.136, 0.413)
 pars_after_shift = c(0.079, 0.973, Inf, 0.652, 0.413)
@@ -108,7 +114,7 @@ island_shift_replicates = DAISIE_SR_sim(
 
 }
 \references{
-Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted). 
+Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted).
 Lake expansion increases equilibrium diversity via the target effect of
 island biogeography
 }

--- a/man/DAISIE_SR_sim.Rd
+++ b/man/DAISIE_SR_sim.Rd
@@ -37,7 +37,7 @@ K=Inf for non-diversity dependence. \cr \code{pars[9]} corresponds to gamma
 (immigration rate)  after the shift \cr \code{pars[10]} corresponds to
 lambda^a (anagenesis rate) after the shift \cr \code{pars[11]} corresponds to
 the time of shift. This is defined as time before the end of the simulation. For example,
-setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and 
+setting time = 4 and pars[11] = 1.5 will simulate with pars[1:5] from 4 to 1.5 and
 with pars[6:10] from 1.5 to 0.}
 
 \item{replicates}{Number of island replicates to be simulated.}
@@ -69,7 +69,7 @@ components: \cr \code{$island_age} - the island age \cr Then, we have:\cr \code{
 - the number of mainland lineages that are not present on the island \cr
 \code{$stt_all} - STT table for all species on the island (nI - number of
 non-endemic species; nA - number of anagenetic species, nC - number of
-cladogenetic species, present - number of independent colonisations present)\cr  
+cladogenetic species, present - number of independent colonisations present)\cr
 The subsequent elements of the list each contain information on a single
 colonist lineage on the island and has 4 components:\cr
 \code{$branching_times} - island age and stem age of the population/species
@@ -84,7 +84,7 @@ particular clade (only applicable for endemic clades) \cr \code{$type_1or2}
 }
 \description{
 This function simulates islands with given cladogenesis, extinction, Kprime,
-immigration and anagenesis parameters that shift at some time. 
+immigration and anagenesis parameters that shift at some time.
 Runs the function with clade-specific
 carrying capacity, where diversity-dependence operates only within single
 clades, i.e. only among species originating from the same mainland
@@ -92,9 +92,15 @@ colonist.
 
 Returns R list object that contains the simulated islands.
 }
+\note{
+This function produces an extra, empty element per replicate when the
+island is empty at time = 0. Functionally this has no effect on the
+simulations, but care should be taken if using the length of objects to count
+the number of species present on the island.
+}
 \examples{
-# Simulate 15 islands for 4 million years with a shift in immigration rate 
-# at 0.195 Ma, and plot the species-through-time plot. Pool size 296. 
+# Simulate 15 islands for 4 million years with a shift in immigration rate
+# at 0.195 Ma, and plot the species-through-time plot. Pool size 296.
 
 pars_before_shift = c(0.079, 0.973, Inf, 0.136, 0.413)
 pars_after_shift = c(0.079, 0.973, Inf, 0.652, 0.413)
@@ -108,7 +114,7 @@ island_shift_replicates = DAISIE_SR_sim(
 
 }
 \references{
-Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted). 
+Hauffe, T., D. Delicado, R.S. Etienne and L. Valente (submitted).
 Lake expansion increases equilibrium diversity via the target effect of
 island biogeography
 }

--- a/man/DAISIE_sim_core_1_4.Rd
+++ b/man/DAISIE_sim_core_1_4.Rd
@@ -30,3 +30,9 @@ this value is set to the number of mainland species.}
 Internal function of the DAISIE simulation
 Taken from CRAN, commit https://github.com/richelbilderbeek/DAISIE/commit/c700b0fcf9e2c2b5d7248f02af7596fac5a2f573#diff-ddae7ad3ae2def3cb66ecf8a8a45cc41
 }
+\note{
+This function produces an extra element per replicate when the
+island is empty at time = 0. Functionally this has no effect on the
+simulations, but care should be taken if using the length of objects to count
+the number of species present on the island.
+}

--- a/man/DAISIE_sim_core_1_4a.Rd
+++ b/man/DAISIE_sim_core_1_4a.Rd
@@ -30,3 +30,9 @@ this value is set to the number of mainland species.}
 Internal function of the DAISIE simulation
 Taken from CRAN, commit https://github.com/richelbilderbeek/DAISIE/commit/c700b0fcf9e2c2b5d7248f02af7596fac5a2f573#diff-ddae7ad3ae2def3cb66ecf8a8a45cc41
 }
+\note{
+This function produces an extra element per replicate when the
+island is empty at time = 0. Functionally this has no effect on the
+simulations, but care should be taken if using the length of objects to count
+the number of species present on the island.
+}


### PR DESCRIPTION
This adds a `@note` section with information regarding the "empty" list elements when `stac = 0` in `DAISIE_SR_sim`, `DAISIE_sim_core_1_4`, `DAISIE_sim_core_1_4a` and adds a comment block with the same information in `DAISIE_sim_core_1_5`