### PR TITLE
Conditioning on number of colonists  on ML and sim - CS model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DAISIE
 Type: Package
 Title: Dynamical Assembly of Islands by Speciation, Immigration and Extinction
-Version: 3.0.1
-Date: 2020-08-25
+Version: 3.1.0
+Date: 2020-09-27
 Depends: R (>= 3.5.0)
 biocViews:
 Imports: 
@@ -81,17 +81,22 @@ Authors@R: c(
     person(given = "Giovanni",
            family = "Laudanno",
            email = "glaudanno@gmail.com",
-           role = c("ctb")),
+           role = c("ctb"),
+           comment = c(ORCID = "0000-0002-2952-3345")),
     person(given = "Nadiah",
            family = "Kristensen",
            email = "nadiah@nadiah.org",
-           role = c("ctb")),
+           role = c("ctb"),
+           comment = c(ORCID = "0000-0002-9720-4581")),
     person(given = "Raphael",
            family = "Scherrer",
            email = "r.scherrer@rug.nl",
            role = c("ctb")))
 License: GPL-3
-Description: Simulates and computes the (maximum) likelihood of a dynamical model of island biota assembly through speciation, immigration and extinction. See e.g. Valente et al. 2015. Ecology Letters 18: 844-852, <DOI:10.1111/ele.12461>.
+Description: Simulates and computes the (maximum) likelihood of a dynamical 
+    model of island biota assembly through speciation, immigration and
+    extinction. See e.g. Valente et al. 2015. Ecology Letters 18: 844-852,
+    <DOI:10.1111/ele.12461>.
 NeedsCompilation: yes
 Encoding: UTF-8
 VignetteBuilder: knitr

--- a/R/DAISIE_SR_loglik_CS.R
+++ b/R/DAISIE_SR_loglik_CS.R
@@ -72,50 +72,10 @@ DAISIE_SR_loglik_CS_M1 <- DAISIE_SR_loglik <- function(
   reltolint = reltolint,
   verbose = FALSE
 ) {
-  # brts = branching times (positive, from present to past)
-  # - max(brts) = age of the island
-  # - next largest brts = stem age / time of divergence from the mainland
-  # The interpretation of this depends on stac (see below)
-  # For stac = 0, there is no other value.
-  # For stac = 1 and stac = 5, this is the time since divergence from the immigrant's sister on the mainland.
-  # The immigrant must have immigrated at some point since then.
-  # For stac = 2 and stac = 3, this is the time since divergence from the mainland.
-  # The immigrant that established the clade on the island must have immigrated precisely at this point.
-  # For stac = 3, it must have reimmigrated, but only after the first immigrant had undergone speciation.
-  # - min(brts) = most recent branching time (only for stac = 2, or stac = 3)
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond = conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island (not used in this single loglikelihood)
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
-  # stac = status of the clade formed by the immigrant
-  #  . stac == 0 : immigrant is not present and has not formed an extant clade
-  #  . stac == 1 : immigrant is present but has not formed an extant clade
-  #  . stac == 2 : immigrant is not present but has formed an extant clade
-  #  . stac == 3 : immigrant is present and has formed an extant clade
-  #  . stac == 4 : immigrant is present but has not formed an extant clade, and it is known when it immigrated.
-  #  . stac == 5 : immigrant is not present and has not formed an extant clade, but only an endemic species
-  # missnumspec = number of missing species
   if (is.na(pars2[4])) {
     pars2[4] <- 0
   }
   ddep <- pars2[2]
-  cond <- pars2[3]
-  if (cond > 0) {
-    cat("Conditioning has not been implemented and may not make sense. Cond is set to 0.\n")
-  }
   lac <- pars1[1]
   mu <- pars1[2]
   K <- pars1[3]
@@ -297,47 +257,69 @@ DAISIE_SR_loglik_CS_M1 <- DAISIE_SR_loglik <- function(
 #'
 #' @aliases DAISIE_SR_loglik_CS DAISIE_SR_loglik_all
 #'
-#' @param pars1 Contains the model parameters: \cr \cr \code{pars1[1]}
-#' corresponds to lambda^c (cladogenesis rate) \cr \code{pars1[2]} corresponds
-#' to mu (extinction rate) \cr \code{pars1[3]} corresponds to K (clade-level
-#' carrying capacity) \cr \code{pars1[4]} corresponds to gamma (immigration
-#' rate) \cr \code{pars1[5]} corresponds to lambda^a (anagenesis rate) \cr
+#' @param pars1 Contains the model parameters: \cr \cr
+#' \code{pars1[1]}
+#' corresponds to lambda^c (cladogenesis rate) \cr
+#' \code{pars1[2]} corresponds
+#' to mu (extinction rate) \cr
+#' \code{pars1[3]} corresponds to K (clade-level
+#' carrying capacity) \cr
+#' \code{pars1[4]} corresponds to gamma (immigration
+#' rate) \cr
+#' \code{pars1[5]} corresponds to lambda^a (anagenesis rate) \cr
 #' \code{pars1[6]} corresponds to lambda^c (cladogenesis rate) after the shift
-#' \cr \code{pars1[7]} corresponds to mu (extinction rate) after the shift \cr
+#' \cr
+#' \code{pars1[7]} corresponds to mu (extinction rate) after the shift \cr
 #' \code{pars1[8]} corresponds to K (clade-level carrying capacity) after the
-#' shift \cr \code{pars1[9]} corresponds to gamma (immigration rate) after the
-#' shift \cr \code{pars1[10]} corresponds to lambda^a (anagenesis rate) after
-#' the shift \cr \code{pars1[11]} corresponds to the time of shift \cr
-#' @param pars2 Contains the model settings \cr \cr \code{pars2[1]} corresponds
-#' to lx = length of ODE variable x \cr \code{pars2[2]} corresponds to ddmodel
-#' = diversity-dependent model, model of diversity-dependence, which can be one
-#' of\cr \cr ddmodel = 0 : no diversity dependence \cr ddmodel = 1 : linear
-#' dependence in speciation rate \cr ddmodel = 11: linear dependence in
-#' speciation rate and in immigration rate \cr ddmodel = 2 : exponential
-#' dependence in speciation rate\cr ddmodel = 21: exponential dependence in
-#' speciation rate and in immigration rate\cr \cr \code{pars2[3]} corresponds
-#' to cond = setting of conditioning\cr \cr cond = 0 : conditioning on island
-#' age \cr cond = 1 : conditioning on island age and non-extinction of the
-#' island biota \cr \cr \code{pars2[4]} sets whether parameters and likelihood
-#' should be printed (1) or not (0)
+#' shift \cr
+#' \code{pars1[9]} corresponds to gamma (immigration rate) after the
+#' shift \cr
+#' \code{pars1[10]} corresponds to lambda^a (anagenesis rate) after
+#' the shift \cr
+#' \code{pars1[11]} corresponds to the time of shift \cr
+#' @param pars2 Contains the model settings \cr \cr
+#' \code{pars2[1]} corresponds
+#' to lx = length of ODE variable x \cr
+#' \code{pars2[2]} corresponds to ddmodel = diversity-dependent model,
+#' model of diversity-dependence, which can be one of\cr \cr
+#' ddmodel = 0 : no diversity dependence \cr
+#' ddmodel = 1 : linear dependence in speciation rate \cr
+#' ddmodel = 11: linear dependence in speciation rate and in immigration rate \cr
+#' ddmodel = 2 : exponential dependence in speciation rate\cr
+#' ddmodel = 21: exponential dependence in speciation rate and in immigration rate\cr \cr
+#' \code{pars2[3]} corresponds
+#' to cond = setting of conditioning\cr \cr
+#' cond = 0 : conditioning on island age \cr
+#' cond = 1 : conditioning on island age and non-extinction of the
+#' island biota \cr
+#' cond > 1 : conditioning on island age and having at least cond colonizations on the island \cr \cr
+#' \code{pars2[4]} sets whether parameters and likelihood should be printed (1) or not (0)
 #' @param datalist Data object containing information on colonisation and
 #' branching times. This object can be generated using the DAISIE_dataprep
 #' function, which converts a user-specified data table into a data object, but
 #' the object can of course also be entered directly. It is an R list object
-#' with the following elements.\cr The first element of the list has two or
-#' three components: \cr \cr \code{$island_age} - the island age \cr Then,
-#' depending on whether a distinction between types is made, we have:\cr
+#' with the following elements.\cr
+#' The first element of the list has two or three components: \cr \cr
+#' \code{$island_age} - the island age \cr
+#' Then, depending on whether a distinction between types is made, we have:\cr
 #' \code{$not_present} - the number of mainland lineages that are not present
-#' on the island \cr The remaining elements of the list each contains
+#' on the island \cr
+#' The remaining elements of the list each contains
 #' information on a single colonist lineage on the island and has 5
-#' components:\cr \cr \code{$colonist_name} - the name of the species or clade
-#' that colonized the island \cr \code{$branching_times} - island age and stem
+#' components:\cr \cr
+#' \code{$colonist_name} - the name of the species or clade
+#' that colonized the island \cr
+#' \code{$branching_times} - island age and stem
 #' age of the population/species in the case of Non-endemic, Non-endemic_MaxAge
 #' and Endemic anagenetic species. For cladogenetic species these should be
 #' island age and branching times of the radiation including the stem age of
-#' the radiation.\cr \code{$stac} - the status of the colonist \cr \cr *
-#' Non_endemic_MaxAge: 1 \cr * Endemic: 2 \cr * Endemic&Non_Endemic: 3 \cr *
-#' Non_endemic: 4 \cr * Endemic_MaxAge: 5 \cr \cr \code{$missing_species} -
+#' the radiation.\cr
+#' \code{$stac} - the status of the colonist \cr \cr
+#' - Non_endemic_MaxAge: 1 \cr * Endemic: 2 \cr
+#' - Endemic&Non_Endemic: 3 \cr
+#' - Non_endemic: 4 \cr
+#' - Endemic_MaxAge: 5 \cr \cr
+#' \code{$missing_species} -
 #' number of island species that were not sampled for particular clade (only
 #' applicable for endemic clades) \cr
 #' @param methode Method of the ODE-solver. See package deSolve for details.
@@ -375,47 +357,6 @@ DAISIE_SR_loglik_CS <- DAISIE_SR_loglik_all <- function(
   reltolint = 1E-10,
   verbose = FALSE
 ) {
-  # datalist = list of all data: branching times, status of clade, and numnber of missing species
-  # datalist[[,]][1] = list of branching times (positive, from present to past)
-  # - max(brts) = age of the island
-  # - next largest brts = stem age / time of divergence from the mainland
-  # The interpretation of this depends on stac (see below)
-  # For stac = 0, this needs to be specified only once.
-  # For stac = 1, this is the time since divergence from the immigrant's sister on the mainland.
-  # The immigrant must have immigrated at some point since then.
-  # For stac = 2 and stac = 3, this is the time since divergence from the mainland.
-  # The immigrant that established the clade on the island must have immigrated precisely at this point.
-  # For stac = 3, it must have reimmigrated, but only after the first immigrant had undergone speciation.
-  # - min(brts) = most recent branching time (only for stac = 2, or stac = 3)
-  # datalist[[,]][2] = list of status of the clades formed by the immigrant
-  #  . stac == 0 : immigrant is not present and has not formed an extant clade
-  # Instead of a list of zeros, here a number must be given with the number of clades having stac = 0
-  #  . stac == 1 : immigrant is present but has not formed an extant clade
-  #  . stac == 2 : immigrant is not present but has formed an extant clade
-  #  . stac == 3 : immigrant is present and has formed an extant clade
-  #  . stac == 4 : immigrant is present but has not formed an extant clade, and it is known when it immigrated.
-  #  . stac == 5 : immigrant is not present and has not formed an extant clade, but only an endemic species
-  # datalist[[,]][3] = list with number of missing species in clades for stac = 2 and stac = 3;
-  # for stac = 0 and stac = 1, this number equals 0.
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # - pars1[6]...pars1[10] = same as pars1[1]...pars1[5], but after the shift
-  # - pars1[11] = time of shift
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond = conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island (not used in this single loglikelihood)
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
   pars1 = as.numeric(pars1)
   check_shift_loglik = shift_before_certain_brts(datalist, pars1)
   if(check_shift_loglik != 0){
@@ -440,7 +381,7 @@ DAISIE_SR_loglik_CS <- DAISIE_SR_loglik_all <- function(
   }
   loglik <- not_present * logp0
   numimm <- not_present + length(datalist) - 1
-  logcond <- (cond == 1) * log(1 - exp(numimm * logp0))
+  logcond <- logcondprob(numcolmin = cond,numimm = numimm,logp0 = logp0)
   loglik <- loglik - logcond
   if (length(datalist) > 1) {
     for (i in 2:length(datalist)) {

--- a/R/DAISIE_loglik_CS.R
+++ b/R/DAISIE_loglik_CS.R
@@ -247,42 +247,6 @@ DAISIE_loglik_CS_M1 <- DAISIE_loglik <- function(pars1,
                                                  abstolint = 1E-16,
                                                  reltolint = 1E-10,
                                                  verbose) {
-  # brts = branching times (positive, from present to past)
-  # - max(brts) = age of the island
-  # - next largest brts = stem age / time of divergence from the mainland
-  # The interpretation of this depends on stac (see below)
-  # For stac = 0, there is no other value.
-  # For stac = 1 and stac = 5, this is the time since divergence from the
-  # immigrant's sister on the mainland.
-  # The immigrant must have immigrated at some point since then.
-  # For stac = 2 and stac = 3, this is the time since
-  # divergence from the mainland.
-  # The immigrant that established the clade on the island must have
-  # immigrated precisely at this point.
-  # For stac = 3, it must have reimmigrated, but only after the first
-  # immigrant had undergone speciation.
-  # - min(brts) = most recent branching time (only for stac = 2, or stac = 3)
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate
-  #  (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond = conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island (not used in this
-  #  single loglikelihood)
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
-  # - pars2[5] = island ontonogeny. If NULL, then constant ontogeny is assumed
-  # missnumspec = number of missing species
   # stac = status of the clade formed by the immigrant
   #  . stac == 1 : immigrant is present but has not formed an extant clade
   #  . stac == 2 : immigrant is not present but has formed an extant clade
@@ -313,10 +277,6 @@ DAISIE_loglik_CS_M1 <- DAISIE_loglik <- function(pars1,
   #   pars2[5] <- 0
   # }
   island_ontogeny <- pars2[5]
-  if (cond > 0) {
-    cat("Conditioning has not been implemented and may not make sense.
-        Cond is set to 0.\n")
-  }
   if (is.na(island_ontogeny)) # This calls the old code that doesn't expect
     # ontogeny
   {
@@ -750,63 +710,6 @@ DAISIE_loglik_CS <- DAISIE_loglik_all <- function(pars1,
                                                   CS_version = 1,
                                                   abstolint = 1E-16,
                                                   reltolint = 1E-10) {
-  # datalist = list of all data: branching times, status of clade,
-  # and numnber of missing species
-  # datalist[[,]][1] = list of branching times (positive, from present to past)
-  # - max(brts) = age of the island
-  # - next largest brts = stem age / time of divergence from the mainland
-  # The interpretation of this depends on stac (see below)
-  # For stac = 0, this needs to be specified only once.
-  # For stac = 1, this is the time since divergence from the
-  # immigrant's sister on the mainland.
-  # The immigrant must have immigrated at some point since then.
-  # For stac = 2 and stac = 3, this is the time since
-  # divergence from the mainland.
-  # The immigrant that established the clade on the island must have immigrated
-  #  precisely at this point.
-  # For stac = 3, it must have reimmigrated, but only after the first immigrant
-  #  had undergone speciation.
-  # - min(brts) = most recent branching time (only for stac = 2, or stac = 3)
-  # datalist[[,]][2] = list of status of the clades formed by the immigrant
-  #  . stac == 0 : immigrant is not present and has not formed an extant clade
-  # Instead of a list of zeros, here a number must be given with the number of
-  # clades having stac = 0
-  #  . stac == 1 : immigrant is present but has not formed an extant clade
-  #  . stac == 2 : immigrant is not present but has formed an extant clade
-  #  . stac == 3 : immigrant is present and has formed an extant clade
-  #  . stac == 4 : immigrant is present but has not formed an extant clade,
-  #  and it is known when it immigrated.
-  #  . stac == 5 : immigrant is not present and has not formed an extant clade,
-  #  but only an endemic species
-  #  . stac == 6 : like 2, but with max colonization time
-  #  . stac == 7 : like 3, but with max colonization time
-  # datalist[[,]][3] = list with number of missing species in
-  #  clades for stac = 2 and stac = 3;
-  # for stac = 0 and stac = 1, this number equals 0.
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # - pars1[6]...pars1[10] = same as pars1[1]...pars1[5],
-  # but for a second type of immigrant
-  # - pars1[11] = proportion of type 2 immigrants in species pool
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate
-  #   (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond : conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island
-  #  . cond > 1 : conditioning on island age and having at least cond colonizations on the island \cr \cr
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
-  # - pars2[5] = island ontonogeny. If NA, then constant ontogeny is assumed
-
   pars1 = as.numeric(pars1)
   cond = pars2[3]
   endpars1 <- 5

--- a/R/DAISIE_loglik_CS.R
+++ b/R/DAISIE_loglik_CS.R
@@ -928,7 +928,7 @@ logcondprob <- function(numcolmin, numimm, logp0) {
     if(length(logp0) == 2) {
        pc2 <- DDD::conv(pc[,1],pc[,2])[1:numcolmin]
        logcond <- log(1 - sum(pc2) - (numcolmin > 1) *
-            (pc[1,1] * pc[numcolmin + 1,2] - pc[numcolmin + 1,1] * pc[1,2]))
+            (pc[1,1] * pc[numcolmin + 1,2] + pc[numcolmin + 1,1] * pc[1,2]))
     } else {
        logcond <- log(1 - sum(pc[-(numcolmin + 1)]))
     }

--- a/R/DAISIE_loglik_CS.R
+++ b/R/DAISIE_loglik_CS.R
@@ -927,8 +927,8 @@ logcondprob <- function(numcolmin, numimm, logp0) {
     pc <- exp(logpc)
     if(length(logp0) == 2) {
        pc2 <- DDD::conv(pc[,1],pc[,2])[1:numcolmin]
-       print(pc2)
-       logcond <- log(1 - sum(pc2) - pc[1,1] * pc[numcolmin + 1,2] - pc[numcolmin + 1,1] * pc[1,2])
+       logcond <- log(1 - sum(pc2) - (numcolmin > 1) *
+            (pc[1,1] * pc[numcolmin + 1,2] - pc[numcolmin + 1,1] * pc[1,2]))
     } else {
        logcond <- log(1 - sum(pc[-(numcolmin + 1)]))
     }

--- a/R/DAISIE_loglik_IW.R
+++ b/R/DAISIE_loglik_IW.R
@@ -297,6 +297,9 @@ DAISIE_loglik_IW <- function(
 
   ddep = pars2[2]
   cond = pars2[3]
+  if (cond > 1) {
+    stop('cond > 1 has not been implemented for the island-wide model.')
+  }
 
   lac = pars1[1]
   mu = pars1[2]

--- a/R/DAISIE_loglik_IW0.R
+++ b/R/DAISIE_loglik_IW0.R
@@ -94,26 +94,7 @@ DAISIE_loglik_IW0 <- function(
   methode = "ode45",
   abstolint = 1E-16,
   reltolint = 1E-14,
-  verbose = verbose
-  ) {
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # - pars1[6] = M = number of mainland species
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond = conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island (not used in this single loglikelihood)
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
+  verbose = verbose) {
 
   brts <- c(-abs(datalist[[1]]$brts_table[, 1]), 0)
   clade <- datalist[[1]]$brts_table[, 2]
@@ -122,6 +103,9 @@ DAISIE_loglik_IW0 <- function(
 
   ddep <- pars2[2]
   cond <- pars2[3]
+  if (cond > 1) {
+    stop('cond > 1 has not been implemented in the island-wide model.')
+  }
 
   lac <- pars1[1]
   mu <- pars1[2]
@@ -235,7 +219,7 @@ DAISIE_loglik_IW0 <- function(
   } else {
     decstatus <- 0
   }
-  print(loglik + log(probs))
+  #print(loglik + log(probs))
   loglik <- loglik + log(probs[1 + nonendemic, 1 + endemic, 1 + decstatus])
 
   if (cond > 0) {
@@ -274,23 +258,6 @@ DAISIE_loglik_IW_M1 <- function(
   reltolint = 1E-14,
   verbose
   ) {
-  # pars1 = model parameters
-  # - pars1[1] = lac = (initial) cladogenesis rate
-  # - pars1[2] = mu = extinction rate
-  # - pars1[3] = K = maximum number of species possible in the clade
-  # - pars1[4] = gam = (initial) immigration rate
-  # - pars1[5] = laa = (initial) anagenesis rate
-  # pars2 = model settings
-  # - pars2[1] = lx = length of ODE variable x
-  # - pars2[2] = ddep = diversity-dependent model,mode of diversity-dependence
-  #  . ddep == 0 : no diversity-dependence
-  #  . ddep == 1 : linear dependence in speciation rate (anagenesis and cladogenesis)
-  #  . ddep == 11 : linear dependence in speciation rate and immigration rate
-  #  . ddep == 3 : linear dependence in extinction rate
-  # - pars2[3] = cond = conditioning
-  #  . cond == 0 : no conditioning
-  #  . cond == 1 : conditioning on presence on the island (not used in this single loglikelihood)
-  # - pars2[4] = parameters and likelihood should be printed (1) or not (0)
 
   if (is.na(pars2[4])) {
     pars2[4] <- 0

--- a/R/DAISIE_sim_constant_rate.R
+++ b/R/DAISIE_sim_constant_rate.R
@@ -178,6 +178,7 @@ DAISIE_sim_constant_rate <- DAISIE_sim <- function(
     sea_level_amplitude = 0,
     sea_level_frequency = 0,
     island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 ) {
@@ -226,15 +227,25 @@ DAISIE_sim_constant_rate <- DAISIE_sim <- function(
       for (rep in 1:replicates) {
         island_replicates[[rep]] <- list()
         full_list <- list()
-        for (m_spec in 1:M) {
-          full_list[[m_spec]] <- DAISIE_sim_core_constant_rate(
-            time = totaltime,
-            mainland_n = 1,
-            pars = pars,
-            nonoceanic_pars = nonoceanic_pars,
-            hyper_pars = hyper_pars,
-            area_pars = area_pars
-          )
+        if (cond == 0) {
+          number_present <- -1
+        } else {
+          number_present <- 0
+        }
+        while (number_present < cond) {
+          for (m_spec in 1:M) {
+            full_list[[m_spec]] <- DAISIE_sim_core_constant_rate(
+              time = totaltime,
+              mainland_n = 1,
+              pars = pars,
+              nonoceanic_pars = nonoceanic_pars,
+              hyper_pars = hyper_pars,
+              area_pars = area_pars
+            )
+          }
+          stac_vec <- unlist(full_list)[which(names(unlist(full_list)) == "stac")]
+          present <- which(stac_vec != 0)
+          number_present <- length(present)
         }
         island_replicates[[rep]] <- full_list
         if (verbose == TRUE) {

--- a/R/DAISIE_sim_constant_rate_shift.R
+++ b/R/DAISIE_sim_constant_rate_shift.R
@@ -80,6 +80,7 @@ DAISIE_sim_constant_rate_shift <- function(
     sea_level_amplitude = 0,
     sea_level_frequency = 0,
     island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 ) {
@@ -114,9 +115,15 @@ DAISIE_sim_constant_rate_shift <- function(
                                           verbose = verbose)
   }
   if (divdepmodel == "CS") {
-      for (rep in 1:replicates) {
-        island_replicates[[rep]] <- list()
-        full_list <- list()
+    for (rep in 1:replicates) {
+      island_replicates[[rep]] <- list()
+      full_list <- list()
+      if (cond == 0) {
+        number_present <- -1
+      } else {
+        number_present <- 0
+      }
+      while (number_present < cond) {
         for (m_spec in 1:M) {
           full_list[[m_spec]] <- DAISIE_sim_core_constant_rate_shift(
             time = totaltime,
@@ -128,11 +135,15 @@ DAISIE_sim_constant_rate_shift <- function(
             shift_times = shift_times
           )
         }
-        island_replicates[[rep]] <- full_list
-        if (verbose == TRUE) {
-          print(paste("Island replicate ", rep, sep = ""))
-        }
+        stac_vec <- unlist(full_list)[which(names(unlist(full_list)) == "stac")]
+        present <- which(stac_vec != 0)
+        number_present <- length(present)
       }
+      island_replicates[[rep]] <- full_list
+      if (verbose == TRUE) {
+        print(paste("Island replicate ", rep, sep = ""))
+      }
+    }
     island_replicates <- DAISIE_format_CS(
       island_replicates = island_replicates,
       time = totaltime,

--- a/R/DAISIE_sim_relaxed_rate.R
+++ b/R/DAISIE_sim_relaxed_rate.R
@@ -108,6 +108,7 @@ DAISIE_sim_relaxed_rate <- function(
     sea_level_amplitude = 0,
     sea_level_frequency = 0,
     island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 ) {
@@ -123,18 +124,28 @@ DAISIE_sim_relaxed_rate <- function(
   for (rep in 1:replicates) {
     island_replicates[[rep]] <- list()
     full_list <- list()
-    for (m_spec in 1:M) {
-      relaxed_pars <- sample_relaxed_rate(
-        pars = pars,
-        relaxed_par = relaxed_par)
-      full_list[[m_spec]] <- DAISIE_sim_core_constant_rate(
-        time = totaltime,
-        mainland_n = 1,
-        pars = relaxed_pars,
-        nonoceanic_pars = nonoceanic_pars,
-        hyper_pars = hyper_pars,
-        area_pars = area_pars
-      )
+    if (cond == 0) {
+      number_present <- -1
+    } else {
+      number_present <- 0
+    }
+    while (number_present < cond) {
+      for (m_spec in 1:M) {
+        relaxed_pars <- sample_relaxed_rate(
+          pars = pars,
+          relaxed_par = relaxed_par)
+        full_list[[m_spec]] <- DAISIE_sim_core_constant_rate(
+          time = totaltime,
+          mainland_n = 1,
+          pars = relaxed_pars,
+          nonoceanic_pars = nonoceanic_pars,
+          hyper_pars = hyper_pars,
+          area_pars = area_pars
+        )
+      }
+      stac_vec <- unlist(full_list)[which(names(unlist(full_list)) == "stac")]
+      present <- which(stac_vec != 0)
+      number_present <- length(present)
     }
     island_replicates[[rep]] <- full_list
     if (verbose == TRUE) {

--- a/R/default_params_doc.R
+++ b/R/default_params_doc.R
@@ -239,6 +239,8 @@
 #'   immigration rate\cr
 #' @param cond cond = 0 : conditioning on island age \cr cond = 1 :
 #'   conditioning on island age and non-extinction of the island biota \cr.
+#'   cond > 1 : conditioning on island age and having at least cond colonizations
+#'   on the island. This last option is not yet available for the IW model \cr
 #' @param eqmodel Sets the equilibrium constraint that can be used during the
 #'   likelihood optimization. Only available for datatype = 'single'.\cr\cr
 #'   eqmodel = 0 : no equilibrium is assumed \cr eqmodel = 13 : near-equilibrium
@@ -331,7 +333,7 @@
 #' @param num_immigrants A numeric with the current number of non-endemic
 #' species (a.k.a non-endemic species).
 #' @param global_min_area_time stub
-#' @param global_max_area_time  stub
+#' @param global_max_area_time stub
 #' @param distance_type Use 'continent' if the distance to the continent should
 #'   be used, use 'nearest_big' if the distance to the nearest big landmass
 #'   should be used, and use 'biologically_realistic' if the distance should

--- a/README.md
+++ b/README.md
@@ -8,14 +8,10 @@ Branch|[Travis](https://travis-ci.org)|[Codecov](https://www.codecov.io)
 ---|---|---
 `master`|[![Build Status](https://travis-ci.org/rsetienne/DAISIE.svg?branch=master)](https://travis-ci.org/rsetienne/DAISIE)|[![codecov.io](https://codecov.io/github/rsetienne/DAISIE/coverage.svg?branch=master)](https://codecov.io/github/rsetienne/DAISIE/branch/master)
 `develop`|[![Build Status](https://travis-ci.org/rsetienne/DAISIE.svg?branch=develop)](https://travis-ci.org/rsetienne/DAISIE)|[![codecov.io](https://codecov.io/github/rsetienne/DAISIE/coverage.svg?branch=develop)](https://codecov.io/github/rsetienne/DAISIE/branch/develop)
-`rampal`|[![Build Status](https://travis-ci.org/rsetienne/DAISIE.svg?branch=rampal)](https://travis-ci.org/rsetienne/DAISIE)|[![codecov.io](https://codecov.io/github/rsetienne/DAISIE/coverage.svg?branch=rampal)](https://codecov.io/github/rsetienne/DAISIE/branch/rampal)
-`luis`|[![Build Status](https://travis-ci.org/rsetienne/DAISIE.svg?branch=luis)](https://travis-ci.org/rsetienne/DAISIE)|[![codecov.io](https://codecov.io/github/rsetienne/DAISIE/coverage.svg?branch=luis)](https://codecov.io/github/rsetienne/DAISIE/branch/luis)
-
 
 ## Installing DAISIE
 
-The DAISIE package has a stable version on [CRAN](https://CRAN.R-project.org/package=DAISIE) and
-a development version on GitHub.
+The DAISIE package has a stable version on [CRAN](https://CRAN.R-project.org/package=DAISIE) and a development version on GitHub.
 
 ### From CRAN
 
@@ -65,25 +61,22 @@ Remotes:
 
  * `master`: build should always pass. [@rsetienne](https://github.com/rsetienne) has control over `develop` to `master` merges.
  * `develop`: merge of topic branches, merge with `master` by [@rsetienne](https://github.com/rsetienne) iff build passes.
- * `rampal`: [@rsetienne's](https://github.com/rsetienne) personal branch.
- * `luis`: [@luislvalente's](https://github.com/luislvalente) personal branch.
 
 ## Contributors
 
 DAISIE was originally developed by Rampal S. Etienne, Luis Valente, Albert B. Phillimore and Bart Haegeman.
 
-Additional members working on expanding DAISIE at the [TECE lab](https://github.com/tece-lab), University of Groningen are:
-Joshua Lambert, Pedro S. Neves, Richel J. C. Bilderbeek, Sebastian Mader, Shu Xie.
+Additional members working on expanding DAISIE at the [TECE lab](https://github.com/tece-lab), University of Groningen are: Joshua Lambert, Pedro Neves, Richèl J. C. Bilderbeek, Sebastian Mader, Shu Xie.
 
 ## References
 
-Etienne R. S., Valente, L., Phillimore, A. B., Haegeman, B., Lambert, J. W., Neves, P., Xie, S., & Bilderbeek, R. J. C. (2020). DAISIE: Dynamical Assembly of Islands by Speciation, Immigration and Extinction. R package version 3.0.0. https://cran.r-project.org/package=DAISIE
+Etienne R. S., Valente, L., Phillimore, A. B., Haegeman, B., Lambert, J. W., Neves, P., Xie, S., & Bilderbeek, R. J. C. (2020). DAISIE: Dynamical Assembly of Islands by Speciation, Immigration and Extinction. R package version 3.0.1. https://cran.r-project.org/package=DAISIE
 
-Valente, L.M., Etienne, R.S., & Phillimore, A.B. (2014). The effects of island ontogeny on species diversity and phylogeny. Proceedings of the Royal Society B: Biological Sciences, 281(1784), 20133227–20133227. http://doi.org/10.1098/rspb.2013.3227
+Valente, L., Etienne, R.S., & Phillimore, A.B. (2014). The effects of island ontogeny on species diversity and phylogeny. Proceedings of the Royal Society B: Biological Sciences, 281(1784), 20133227–20133227. http://doi.org/10.1098/rspb.2013.3227
 
-Valente, L.M., Phillimore, A.B., & Etienne, R.S. (2015). Equilibrium and non-equilibrium dynamics simultaneously operate in the Galápagos islands. Ecology Letters, 18(8), 844–852. http://doi.org/10.1111/ele.12461
+Valente, L., Phillimore, A.B., & Etienne, R.S. (2015). Equilibrium and non-equilibrium dynamics simultaneously operate in the Galápagos islands. Ecology Letters, 18(8), 844–852. http://doi.org/10.1111/ele.12461
 
-Valente, L.M., Etienne, R.S., & Dávalos, L.M. (2017). Recent extinctions disturb path to equilibrium diversity in Caribbean bats. Nature Ecology & Evolution, 1(2), 0026. http://doi.org/10.1038/s41559-016-0026
+Valente, L., Etienne, R.S., & Dávalos, L.M. (2017). Recent extinctions disturb path to equilibrium diversity in Caribbean bats. Nature Ecology & Evolution, 1(2), 0026. http://doi.org/10.1038/s41559-016-0026
 
 Valente, L., Illera, J.C., Havenstein, K., Pallien, T., Etienne, R.S., & Tiedemann, R. (2017). Equilibrium Bird Species Diversity in Atlantic Islands. Current Biology, 27(11), 1660-1666. https://doi.org/(...)16/j.cub.2017.04.053
 
@@ -93,4 +86,4 @@ Valente, L., Etienne, R.S., & Garcia-R., J.C. (2019). “Deep Macroevolutionary 
 
 Valente, L., Phillimore, A.B., Melo, M., Warren, B.H., Clegg, S.M., Havenstein, K., Tiedemann, R., Illera, J.C.,, Thebaud, C., Aschenbach, T. & Etienne, R.S. (2020). “A Simple Dynamic Model Explains the Diversity of Island Birds Worldwide.” Nature 579 (7797): 92–96. https://doi.org/10.1038/s41586-020-2022-5.
 
-Hauffe, T., Delicado, D., Etienne, R.S., & Valente, L. (2020). Lake expansion elevates equilibrium diversity via increasing colonization. Journal of Biogeography. In press. https://doi.org/10.1111/jbi.13914.
+Hauffe, T., Delicado, D., Etienne, R.S., & Valente, L. (2020). Lake expansion elevates equilibrium diversity via increasing colonization. Journal of Biogeography 47: 1849–1860. https://doi.org/10.1111/jbi.13914

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/DAISIE)](https://cran.r-project.org/package=DAISIE)
 [![](http://cranlogs.r-pkg.org/badges/grand-total/DAISIE)]( https://CRAN.R-project.org/package=DAISIE)
 [![](http://cranlogs.r-pkg.org/badges/DAISIE)](https://CRAN.R-project.org/package=DAISIE)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/rsetienne/DAISIE)
 
 Branch|[Travis](https://travis-ci.org)|[Codecov](https://www.codecov.io)
 ---|---|---

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Valente, L., Phillimore, A.B., & Etienne, R.S. (2015). Equilibrium and non-equil
 
 Valente, L., Etienne, R.S., & Dávalos, L.M. (2017). Recent extinctions disturb path to equilibrium diversity in Caribbean bats. Nature Ecology & Evolution, 1(2), 0026. http://doi.org/10.1038/s41559-016-0026
 
-Valente, L., Illera, J.C., Havenstein, K., Pallien, T., Etienne, R.S., & Tiedemann, R. (2017). Equilibrium Bird Species Diversity in Atlantic Islands. Current Biology, 27(11), 1660-1666. https://doi.org/(...)16/j.cub.2017.04.053
+Valente, L., Illera, J.C., Havenstein, K., Pallien, T., Etienne, R.S., & Tiedemann, R. (2017). Equilibrium Bird Species Diversity in Atlantic Islands. Current Biology, 27(11), 1660-1666. https://doi.org/10.1016/j.cub.2017.04.053
 
 Valente, L., Phillimore, A.B., & Etienne, R.S. (2018). Using molecular phylogenies in island biogeography: It’s about time. Ecography, 1–3. http://doi.org/10.1111/ecog.03503
 
-Valente, L., Etienne, R.S., & Garcia-R., J.C. (2019). “Deep Macroevolutionary Impact of Humans on New Zealand’s Unique Avifauna.” Current Biology 29 (15): 2563-2569.e4. https://doi.org/10.1016/j.cub.2019.06.058.
+Valente, L., Etienne, R.S., & Garcia-R., J.C. (2019). “Deep Macroevolutionary Impact of Humans on New Zealand’s Unique Avifauna.” Current Biology 29 (15): 2563-2569.e4. https://doi.org/10.1016/j.cub.2019.06.058
 
-Valente, L., Phillimore, A.B., Melo, M., Warren, B.H., Clegg, S.M., Havenstein, K., Tiedemann, R., Illera, J.C.,, Thebaud, C., Aschenbach, T. & Etienne, R.S. (2020). “A Simple Dynamic Model Explains the Diversity of Island Birds Worldwide.” Nature 579 (7797): 92–96. https://doi.org/10.1038/s41586-020-2022-5.
+Valente, L., Phillimore, A.B., Melo, M., Warren, B.H., Clegg, S.M., Havenstein, K., Tiedemann, R., Illera, J.C.,, Thebaud, C., Aschenbach, T. & Etienne, R.S. (2020). “A Simple Dynamic Model Explains the Diversity of Island Birds Worldwide.” Nature 579 (7797): 92–96. https://doi.org/10.1038/s41586-020-2022-5
 
 Hauffe, T., Delicado, D., Etienne, R.S., & Valente, L. (2020). Lake expansion elevates equilibrium diversity via increasing colonization. Journal of Biogeography 47: 1849–1860. https://doi.org/10.1111/jbi.13914

--- a/man/DAISIE-package.Rd
+++ b/man/DAISIE-package.Rd
@@ -48,8 +48,8 @@ Authors:
 Other contributors:
 \itemize{
   \item Torsten Hauffe \email{torsten.hauffe@gmail.com} (\href{https://orcid.org/0000-0001-5711-9457}{ORCID}) [contributor]
-  \item Giovanni Laudanno \email{glaudanno@gmail.com} [contributor]
-  \item Nadiah Kristensen \email{nadiah@nadiah.org} [contributor]
+  \item Giovanni Laudanno \email{glaudanno@gmail.com} (\href{https://orcid.org/0000-0002-2952-3345}{ORCID}) [contributor]
+  \item Nadiah Kristensen \email{nadiah@nadiah.org} (\href{https://orcid.org/0000-0002-9720-4581}{ORCID}) [contributor]
   \item Raphael Scherrer \email{r.scherrer@rug.nl} [contributor]
 }
 

--- a/man/DAISIE-package.Rd
+++ b/man/DAISIE-package.Rd
@@ -23,6 +23,14 @@ Cladogenesis and immigration rates can be dependent on diversity.
 \item Valente, L., Phillimore, A. B., Melo, M., Warren, B. H., Clegg, S. M., Havenstein, K., Etienne, R. S. (2020). A simple dynamic model explains the diversity of island birds worldwide. Nature 579: 92-96. <DOI:10.1038/s41586-020-2022-5>.\cr
 } \cr
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/rsetienne/DAISIE}
+  \item Report bugs at \url{https://github.com/rsetienne/DAISIE/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Rampal S. Etienne \email{r.s.etienne@rug.nl} (\href{https://orcid.org/0000-0003-2142-7612}{ORCID})
 

--- a/man/DAISIE_IC.Rd
+++ b/man/DAISIE_IC.Rd
@@ -75,7 +75,9 @@ e.g. c(1,3) if lambda^c and K should not be optimized.}
 be computed, must be larger than the size of the largest clade.}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{ddmodel}{Sets the model of diversity-dependence: \cr \cr ddmodel = 0 :
 no diversity dependence \cr ddmodel = 1 : linear dependence in speciation

--- a/man/DAISIE_ML.Rd
+++ b/man/DAISIE_ML.Rd
@@ -114,7 +114,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{island_ontogeny}{In \code{\link{DAISIE_sim_time_dependent}()},
 \code{\link{DAISIE_ML_CS}} and plotting a string describing the type of

--- a/man/DAISIE_ML1.Rd
+++ b/man/DAISIE_ML1.Rd
@@ -97,7 +97,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{eqmodel}{Sets the equilibrium constraint that can be used during the
 likelihood optimization. Only available for datatype = 'single'.\cr\cr

--- a/man/DAISIE_ML2.Rd
+++ b/man/DAISIE_ML2.Rd
@@ -97,7 +97,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{island_ontogeny}{In \code{\link{DAISIE_sim_time_dependent}()},
 \code{\link{DAISIE_ML_CS}} and plotting a string describing the type of

--- a/man/DAISIE_ML3.Rd
+++ b/man/DAISIE_ML3.Rd
@@ -89,7 +89,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{island_ontogeny}{In \code{\link{DAISIE_sim_time_dependent}()},
 \code{\link{DAISIE_ML_CS}} and plotting a string describing the type of

--- a/man/DAISIE_ML4.Rd
+++ b/man/DAISIE_ML4.Rd
@@ -89,7 +89,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{tol}{Sets the tolerances in the optimization. Consists of: \cr reltolx
 = relative tolerance of parameter values in optimization \cr reltolf =

--- a/man/DAISIE_ML_IW.Rd
+++ b/man/DAISIE_ML_IW.Rd
@@ -87,7 +87,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{tol}{Sets the tolerances in the optimization. Consists of: \cr reltolx
 = relative tolerance of parameter values in optimization \cr reltolf =

--- a/man/DAISIE_SR_loglik_CS.Rd
+++ b/man/DAISIE_SR_loglik_CS.Rd
@@ -19,49 +19,71 @@ DAISIE_SR_loglik_CS(
 )
 }
 \arguments{
-\item{pars1}{Contains the model parameters: \cr \cr \code{pars1[1]}
-corresponds to lambda^c (cladogenesis rate) \cr \code{pars1[2]} corresponds
-to mu (extinction rate) \cr \code{pars1[3]} corresponds to K (clade-level
-carrying capacity) \cr \code{pars1[4]} corresponds to gamma (immigration
-rate) \cr \code{pars1[5]} corresponds to lambda^a (anagenesis rate) \cr
+\item{pars1}{Contains the model parameters: \cr \cr
+\code{pars1[1]}
+corresponds to lambda^c (cladogenesis rate) \cr
+\code{pars1[2]} corresponds
+to mu (extinction rate) \cr
+\code{pars1[3]} corresponds to K (clade-level
+carrying capacity) \cr
+\code{pars1[4]} corresponds to gamma (immigration
+rate) \cr
+\code{pars1[5]} corresponds to lambda^a (anagenesis rate) \cr
 \code{pars1[6]} corresponds to lambda^c (cladogenesis rate) after the shift
-\cr \code{pars1[7]} corresponds to mu (extinction rate) after the shift \cr
+\cr
+\code{pars1[7]} corresponds to mu (extinction rate) after the shift \cr
 \code{pars1[8]} corresponds to K (clade-level carrying capacity) after the
-shift \cr \code{pars1[9]} corresponds to gamma (immigration rate) after the
-shift \cr \code{pars1[10]} corresponds to lambda^a (anagenesis rate) after
-the shift \cr \code{pars1[11]} corresponds to the time of shift \cr}
+shift \cr
+\code{pars1[9]} corresponds to gamma (immigration rate) after the
+shift \cr
+\code{pars1[10]} corresponds to lambda^a (anagenesis rate) after
+the shift \cr
+\code{pars1[11]} corresponds to the time of shift \cr}
 
-\item{pars2}{Contains the model settings \cr \cr \code{pars2[1]} corresponds
-to lx = length of ODE variable x \cr \code{pars2[2]} corresponds to ddmodel
-= diversity-dependent model, model of diversity-dependence, which can be one
-of\cr \cr ddmodel = 0 : no diversity dependence \cr ddmodel = 1 : linear
-dependence in speciation rate \cr ddmodel = 11: linear dependence in
-speciation rate and in immigration rate \cr ddmodel = 2 : exponential
-dependence in speciation rate\cr ddmodel = 21: exponential dependence in
-speciation rate and in immigration rate\cr \cr \code{pars2[3]} corresponds
-to cond = setting of conditioning\cr \cr cond = 0 : conditioning on island
-age \cr cond = 1 : conditioning on island age and non-extinction of the
-island biota \cr \cr \code{pars2[4]} sets whether parameters and likelihood
-should be printed (1) or not (0)}
+\item{pars2}{Contains the model settings \cr \cr
+\code{pars2[1]} corresponds
+to lx = length of ODE variable x \cr
+\code{pars2[2]} corresponds to ddmodel = diversity-dependent model,
+model of diversity-dependence, which can be one of\cr \cr
+ddmodel = 0 : no diversity dependence \cr
+ddmodel = 1 : linear dependence in speciation rate \cr
+ddmodel = 11: linear dependence in speciation rate and in immigration rate \cr
+ddmodel = 2 : exponential dependence in speciation rate\cr
+ddmodel = 21: exponential dependence in speciation rate and in immigration rate\cr \cr
+\code{pars2[3]} corresponds
+to cond = setting of conditioning\cr \cr
+cond = 0 : conditioning on island age \cr
+cond = 1 : conditioning on island age and non-extinction of the
+island biota \cr
+cond > 1 : conditioning on island age and having at least cond colonizations on the island \cr \cr
+\code{pars2[4]} sets whether parameters and likelihood should be printed (1) or not (0)}
 
 \item{datalist}{Data object containing information on colonisation and
 branching times. This object can be generated using the DAISIE_dataprep
 function, which converts a user-specified data table into a data object, but
 the object can of course also be entered directly. It is an R list object
-with the following elements.\cr The first element of the list has two or
-three components: \cr \cr \code{$island_age} - the island age \cr Then,
-depending on whether a distinction between types is made, we have:\cr
+with the following elements.\cr
+The first element of the list has two or three components: \cr \cr
+\code{$island_age} - the island age \cr
+Then, depending on whether a distinction between types is made, we have:\cr
 \code{$not_present} - the number of mainland lineages that are not present
-on the island \cr The remaining elements of the list each contains
+on the island \cr
+The remaining elements of the list each contains
 information on a single colonist lineage on the island and has 5
-components:\cr \cr \code{$colonist_name} - the name of the species or clade
-that colonized the island \cr \code{$branching_times} - island age and stem
+components:\cr \cr
+\code{$colonist_name} - the name of the species or clade
+that colonized the island \cr
+\code{$branching_times} - island age and stem
 age of the population/species in the case of Non-endemic, Non-endemic_MaxAge
 and Endemic anagenetic species. For cladogenetic species these should be
 island age and branching times of the radiation including the stem age of
-the radiation.\cr \code{$stac} - the status of the colonist \cr \cr *
-Non_endemic_MaxAge: 1 \cr * Endemic: 2 \cr * Endemic&Non_Endemic: 3 \cr *
-Non_endemic: 4 \cr * Endemic_MaxAge: 5 \cr \cr \code{$missing_species} -
+the radiation.\cr
+\code{$stac} - the status of the colonist \cr \cr
+- Non_endemic_MaxAge: 1 \cr * Endemic: 2 \cr
+- Endemic&Non_Endemic: 3 \cr
+- Non_endemic: 4 \cr
+- Endemic_MaxAge: 5 \cr \cr
+\code{$missing_species} -
 number of island species that were not sampled for particular clade (only
 applicable for endemic clades) \cr}
 

--- a/man/DAISIE_loglik_CS.Rd
+++ b/man/DAISIE_loglik_CS.Rd
@@ -49,6 +49,7 @@ ddmodel = 21: exponential dependence in speciation rate and in immigration rate\
 \code{pars2[3]} corresponds to cond = setting of conditioning\cr \cr
 cond = 0 : conditioning on island age \cr
 cond = 1 : conditioning on island age and non-extinction of the island biota \cr \cr
+cond > 1 : conditioning on island age and having at least cond colonizations on the island \cr \cr
 \code{pars2[4]} sets whether parameters and likelihood should be printed (1) or not (0)}
 
 \item{datalist}{Data object containing information on colonisation and

--- a/man/DAISIE_sim.Rd
+++ b/man/DAISIE_sim.Rd
@@ -134,7 +134,9 @@ created by \code{\link{create_area_pars}()}:
 }}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim.Rd
+++ b/man/DAISIE_sim.Rd
@@ -22,6 +22,7 @@ DAISIE_sim_constant_rate(
   area_pars = create_area_pars(max_area = 1, current_area = 1, proportional_peak_t = 0,
     total_island_age = 0, sea_level_amplitude = 0, sea_level_frequency = 0,
     island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 )
@@ -131,6 +132,9 @@ created by \code{\link{create_area_pars}()}:
   \item{[6]: frequency of sine wave of area change from sea level}
   \item{[7]: angle of the slope of the island}
 }}
+
+\item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
+conditioning on island age and non-extinction of the island biota \cr.}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_constant_rate_shift.Rd
+++ b/man/DAISIE_sim_constant_rate_shift.Rd
@@ -116,7 +116,9 @@ created by \code{\link{create_area_pars}()}:
 }}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_constant_rate_shift.Rd
+++ b/man/DAISIE_sim_constant_rate_shift.Rd
@@ -20,6 +20,7 @@ DAISIE_sim_constant_rate_shift(
   area_pars = DAISIE::create_area_pars(max_area = 1, current_area = 1,
     proportional_peak_t = 0, total_island_age = 0, sea_level_amplitude = 0,
     sea_level_frequency = 0, island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 )
@@ -113,6 +114,9 @@ created by \code{\link{create_area_pars}()}:
   \item{[6]: frequency of sine wave of area change from sea level}
   \item{[7]: angle of the slope of the island}
 }}
+
+\item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
+conditioning on island age and non-extinction of the island biota \cr.}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_relaxed_rate.Rd
+++ b/man/DAISIE_sim_relaxed_rate.Rd
@@ -18,6 +18,7 @@ DAISIE_sim_relaxed_rate(
   area_pars = create_area_pars(max_area = 1, current_area = 1, proportional_peak_t = 0,
     total_island_age = 0, sea_level_amplitude = 0, sea_level_frequency = 0,
     island_gradient_angle = 0),
+  cond = 0,
   verbose = TRUE,
   ...
 )
@@ -99,6 +100,9 @@ created by \code{\link{create_area_pars}()}:
   \item{[6]: frequency of sine wave of area change from sea level}
   \item{[7]: angle of the slope of the island}
 }}
+
+\item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
+conditioning on island age and non-extinction of the island biota \cr.}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_relaxed_rate.Rd
+++ b/man/DAISIE_sim_relaxed_rate.Rd
@@ -102,7 +102,9 @@ created by \code{\link{create_area_pars}()}:
 }}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_time_dependent.Rd
+++ b/man/DAISIE_sim_time_dependent.Rd
@@ -133,7 +133,9 @@ through time.}
 rate preventing it from being too large and slowing down simulation.}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_time_dependent.Rd
+++ b/man/DAISIE_sim_time_dependent.Rd
@@ -20,6 +20,7 @@ DAISIE_sim_time_dependent(
   island_ontogeny = "const",
   sea_level = "const",
   extcutoff = 1000,
+  cond = 0,
   verbose = TRUE,
   ...
 )
@@ -130,6 +131,9 @@ through time.}
 
 \item{extcutoff}{A numeric with the cutoff for the the maximum extinction
 rate preventing it from being too large and slowing down simulation.}
+
+\item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
+conditioning on island age and non-extinction of the island biota \cr.}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_trait_dependent.Rd
+++ b/man/DAISIE_sim_trait_dependent.Rd
@@ -21,6 +21,7 @@ DAISIE_sim_trait_dependent(
     proportional_peak_t = 0, total_island_age = 0, sea_level_amplitude = 0,
     sea_level_frequency = 0, island_gradient_angle = 0),
   extcutoff = 1000,
+  cond = 0,
   verbose = TRUE,
   trait_pars = NULL,
   ...
@@ -132,6 +133,9 @@ created by \code{\link{create_area_pars}()}:
 
 \item{extcutoff}{A numeric with the cutoff for the the maximum extinction
 rate preventing it from being too large and slowing down simulation.}
+
+\item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
+conditioning on island age and non-extinction of the island biota \cr.}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/DAISIE_sim_trait_dependent.Rd
+++ b/man/DAISIE_sim_trait_dependent.Rd
@@ -135,7 +135,9 @@ created by \code{\link{create_area_pars}()}:
 rate preventing it from being too large and slowing down simulation.}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{verbose}{In simulation and dataprep functions a logical,
 \code{Default = TRUE} gives intermediate output should be printed.

--- a/man/default_params_doc.Rd
+++ b/man/default_params_doc.Rd
@@ -419,7 +419,9 @@ rate\cr ddmodel = 21: exponential dependence in speciation rate and in
 immigration rate\cr}
 
 \item{cond}{cond = 0 : conditioning on island age \cr cond = 1 :
-conditioning on island age and non-extinction of the island biota \cr.}
+conditioning on island age and non-extinction of the island biota \cr.
+cond > 1 : conditioning on island age and having at least cond colonizations
+on the island. This last option is not yet available for the IW model \cr}
 
 \item{eqmodel}{Sets the equilibrium constraint that can be used during the
 likelihood optimization. Only available for datatype = 'single'.\cr\cr

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -164,3 +164,116 @@ test_that("The parameter choice for 2type DAISIE_ML works", {
   )
   testthat::expect_equal(fit$loglik, -74.7557, tol = 1E-3)
 })
+
+test_that("conditioning works", {
+  # Cond 0
+  ## 1 type
+  utils::data(Galapagos_datalist, package = "DAISIE")
+  pars1_1type_cond0 <- c(0.2, 0.1, Inf, 0.001, 0.3)
+  pars2_1type_cond0 <- c(40, 11, 0, 0)
+  loglik_CS_1type_cond0 <- DAISIE::DAISIE_loglik_CS(
+    pars1 = pars1_1type_cond0,
+    pars2 = pars2_1type_cond0,
+    datalist = Galapagos_datalist,
+    methode = 'ode45',
+    CS_version = 1
+  )
+  testthat::expect_equal(loglik_CS_1type_cond0,-96.49629968062564)
+
+  ## 2 type
+  utils::data(Galapagos_datalist_2types, package = "DAISIE")
+  pars1_2type_cond0 <- c(
+    0.195442017,
+    0.087959583,
+    Inf,
+    0.002247364,
+    0.873605049,
+    3755.202241,
+    8.909285094,
+    14.99999923,
+    0.002247364,
+    0.873605049,
+    0.163
+  )
+  pars2_2type_cond0 <- c(100, 11, 0, 0)
+  loglik_CS_2type_cond0 <- DAISIE::DAISIE_loglik_CS(
+    pars1_2type_cond0,
+    pars2_2type_cond0,
+    Galapagos_datalist_2types
+  )
+  testthat::expect_equal(loglik_CS_2type_cond0,-61.709482984890265)
+
+  # Cond 1
+  ## 1 type
+  utils::data(Galapagos_datalist, package = "DAISIE")
+  pars1_1type_cond1 <- c(0.2, 0.1, Inf, 0.001, 0.3)
+  pars2_1type_cond1 <- c(40, 11, 1, 0)
+  loglik_CS_1type_cond1 <- DAISIE::DAISIE_loglik_CS(
+    pars1 = pars1_1type_cond1,
+    pars2 = pars2_1type_cond1,
+    datalist = Galapagos_datalist,
+    methode = 'ode45',
+    CS_version = 1
+  )
+  testthat::expect_equal(loglik_CS_1type_cond1,-96.463184608046333)
+
+  ## 2 type
+  utils::data(Galapagos_datalist_2types, package = "DAISIE")
+  pars1_2type_cond1 <- c(
+    0.195442017,
+    0.087959583,
+    Inf,
+    0.002247364,
+    0.873605049,
+    3755.202241,
+    8.909285094,
+    14.99999923,
+    0.002247364,
+    0.873605049,
+    0.163
+  )
+  pars2_2type_cond1 <- c(100, 11, 1, 0)
+  loglik_CS_2type_cond1 <- DAISIE::DAISIE_loglik_CS(
+    pars1_2type_cond1,
+    pars2_2type_cond1,
+    Galapagos_datalist_2types
+  )
+  testthat::expect_equal(loglik_CS_2type_cond1,-61.709153802942346)
+
+  # Cond 5
+  ## 1 type
+  utils::data(Galapagos_datalist, package = "DAISIE")
+  pars1_1type_cond5 <- c(0.2, 0.1, Inf, 0.001, 0.3)
+  pars2_1type_cond5 <- c(40, 11, 5, 0)
+  loglik_CS_1type_cond5 <- DAISIE::DAISIE_loglik_CS(
+    pars1 = pars1_1type_cond5,
+    pars2 = pars2_1type_cond5,
+    datalist = Galapagos_datalist,
+    methode = 'ode45',
+    CS_version = 1
+  )
+  testthat::expect_equal(loglik_CS_1type_cond5,-95.1456087499799423)
+
+  ## 2 type
+  utils::data(Galapagos_datalist_2types, package = "DAISIE")
+  pars1_2type_cond5 <- c(
+    0.195442017,
+    0.087959583,
+    Inf,
+    0.002247364,
+    0.873605049,
+    3755.202241,
+    8.909285094,
+    14.99999923,
+    0.002247364,
+    0.873605049,
+    0.163
+  )
+  pars2_2type_cond5 <- c(100, 11, 5, 0)
+  loglik_CS_2type_cond5 <- DAISIE::DAISIE_loglik_all(
+    pars1_2type_cond5,
+    pars2_2type_cond5,
+    Galapagos_datalist_2types
+  )
+  testthat::expect_equal(loglik_CS_2type_cond5,-61.6412372091700931)
+})

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -275,5 +275,5 @@ test_that("conditioning works", {
     pars2_2type_cond5,
     Galapagos_datalist_2types
   )
-  testthat::expect_equal(loglik_CS_2type_cond5,-61.6412372091700931)
+  testthat::expect_equal(loglik_CS_2type_cond5,-61.5667762281177673)
 })


### PR DESCRIPTION
Expands the possibility of conditioning simulations and MLE of the CS model on the number of colonizing lineages. 

In simulation and ML functions, the `cond` argument can now be greater than one. A non-zero `cond` signifies that the ML or simulation is conditioned on having at least `cond` colonizations on the island.

Implements #121, at sim and ML level.