### PR TITLE
Small change to avoid unnecessary warning message

### DIFF
--- a/R/DAISIE_ExpEIN.R
+++ b/R/DAISIE_ExpEIN.R
@@ -45,7 +45,7 @@ DAISIE_ExpEIN <- function(t, pars, M, initEI = c(0, 0)) {
    DD <- laa + 2 * lac
    E0 <- initEI[1]
    I0 <- initEI[2]
-   if (t == Inf) {
+   if (t[1] == Inf) {
       Imm <- ga * M2 / B
       End <- DD / A * Imm
    } else {


### PR DESCRIPTION
I suggest this tweak to the code because this function gives a warning message when multiple time values are inputed, because this particular step is looking for just a single value. This suggestion does not affect the output of the function, but avoids that warning message.