### PR TITLE
fixed endpars1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DAISIE
 Type: Package
 Title: Dynamical Assembly of Islands by Speciation, Immigration and Extinction
-Version: 4.2.0
-Date: 2022-05-24
+Version: 4.2.1
+Date: 2022-06-08
 Depends: R (>= 3.5.0)
 biocViews:
 SystemRequirements: C++14

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DAISIE 4.2.1
+
+* Bug fixes in `DAISIE_loglik_CS()`on the likelihood code for the continental sampling (probability of initial presence on the island).
+* Bug fix in the `DAISIE_sim_cr_iw()` so replication works correctly.
+
 # DAISIE 4.2.0
 
 * Important bugfixes on estimation when data contains a lineage or a clade for 

--- a/R/DAISIE_loglik_CS.R
+++ b/R/DAISIE_loglik_CS.R
@@ -904,7 +904,11 @@ DAISIE_loglik_CS <- DAISIE_loglik_all <- function(
 
   pars1 <- as.numeric(pars1)
   cond <- pars2[3]
-  endpars1 <- 5
+  if (length(pars1) == 6) {
+    endpars1 <- 6
+  } else {
+    endpars1 <- 5
+  }
 
   if(length(pars1) %in% c(5,6) | !is.na(pars2[5])) {
     if(!is.na(pars2[5]))

--- a/R/DAISIE_sim_cr_iw.R
+++ b/R/DAISIE_sim_cr_iw.R
@@ -15,7 +15,7 @@ DAISIE_sim_cr_iw <- function(total_time,
                              cond,
                              verbose) {
   island_replicates <- list()
-  for (rep in seq_along(replicates)) {
+  for (rep in seq_len(replicates)) {
     if (cond == 0) {
       number_present <- -1
     } else {

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -239,6 +239,8 @@ test_that("DAISIE_ML simple case works with estimating probability of initial
       idparsfix = NULL
     )
   ))
+  options(digits = 15)
+  print(tested_mle)
   expect_equal(tested_mle, expected_mle)
 })
 

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -192,13 +192,13 @@ test_that("DAISIE_ML simple case works with estimating probability of initial
           message = "Run only on CI")
   if (identical(Sys.getenv("OS"), "Windows_NT")) {
     expected_mle <- data.frame(
-      lambda_c = 2.53430497145461,
-      mu = 2.66658569091753,
-      K = 2136343.97554965,
-      gamma = 0.00930345848936764,
-      lambda_a = 1.0119011474385,
-      prob_init_pres = 3.21939792431987e-10,
-      loglik = -75.9925548510873,
+      lambda_c = 2.54079308283855,
+      mu = 2.66563367593515,
+      K = 6249.71023359369,
+      gamma = 0.00919247416324124,
+      lambda_a = 1.01076206116211,
+      prob_init_pres = 9.45796543536632e-06,
+      loglik = -75.9935681347126,
       df = 6L,
       conv = 0L
     )

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -204,25 +204,25 @@ test_that("DAISIE_ML simple case works with estimating probability of initial
     )
   } else if (identical(Sys.info()["sysname"], c(sysname = "Darwin"))) {
     expected_mle <- data.frame(
-      lambda_c = 2.5330538395353,
-      mu = 2.66544727106831,
-      K = 8477857.16185865,
-      gamma = 0.00929919368081989,
-      lambda_a = 1.01226940726093,
-      prob_init_pres = 2.08612789348566e-08,
-      loglik = -75.9925781743204,
+      lambda_c = 2.54079308283855,
+      mu = 2.66563367593515,
+      K = 6249.71023359369,
+      gamma = 0.00919247416324124,
+      lambda_a = 1.01076206116211,
+      prob_init_pres = 9.45796543536632e-06,
+      loglik = 75.9935681347126,
       df = 6L,
       conv = 0L
     )
   } else {
     expected_mle <- data.frame(
-      lambda_c = 2.53432108511347,
-      mu = 2.66677757261811,
-      K = 2155153.9420102,
-      gamma = 0.00930305175196706,
-      lambda_a = 1.01184784588089,
-      prob_init_pres = 2.33936540081158e-10,
-      loglik = -75.9925542005831,
+      lambda_c = 2.54079308283855,
+      mu = 2.66563367593515,
+      K = 6249.71023359369,
+      gamma = 0.00919247416324124,
+      lambda_a = 1.01076206116211,
+      prob_init_pres = 9.45796543536632e-06,
+      loglik = -75.9935681347126,
       df = 6L,
       conv = 0L
     )
@@ -239,8 +239,6 @@ test_that("DAISIE_ML simple case works with estimating probability of initial
       idparsfix = NULL
     )
   ))
-  options(digits = 15)
-  print(tested_mle)
   expect_equal(tested_mle, expected_mle)
 })
 

--- a/tests/testthat/test-integration_DAISIE.R
+++ b/tests/testthat/test-integration_DAISIE.R
@@ -190,43 +190,18 @@ test_that("DAISIE_ML simple case works with estimating probability of initial
           presence", {
   skip_if(Sys.getenv("CI") == "" && !(Sys.getenv("USERNAME") == "rampa"),
           message = "Run only on CI")
-  if (identical(Sys.getenv("OS"), "Windows_NT")) {
-    expected_mle <- data.frame(
-      lambda_c = 2.54079308283855,
-      mu = 2.66563367593515,
-      K = 6249.71023359369,
-      gamma = 0.00919247416324124,
-      lambda_a = 1.01076206116211,
-      prob_init_pres = 9.45796543536632e-06,
-      loglik = -75.9935681347126,
-      df = 6L,
-      conv = 0L
-    )
-  } else if (identical(Sys.info()["sysname"], c(sysname = "Darwin"))) {
-    expected_mle <- data.frame(
-      lambda_c = 2.54079308283855,
-      mu = 2.66563367593515,
-      K = 6249.71023359369,
-      gamma = 0.00919247416324124,
-      lambda_a = 1.01076206116211,
-      prob_init_pres = 9.45796543536632e-06,
-      loglik = 75.9935681347126,
-      df = 6L,
-      conv = 0L
-    )
-  } else {
-    expected_mle <- data.frame(
-      lambda_c = 2.54079308283855,
-      mu = 2.66563367593515,
-      K = 6249.71023359369,
-      gamma = 0.00919247416324124,
-      lambda_a = 1.01076206116211,
-      prob_init_pres = 9.45796543536632e-06,
-      loglik = -75.9935681347126,
-      df = 6L,
-      conv = 0L
-    )
-  }
+
+  expected_mle <- data.frame(
+    lambda_c = 2.54079308283855,
+    mu = 2.66563367593515,
+    K = 6249.71023359369,
+    gamma = 0.00919247416324124,
+    lambda_a = 1.01076206116211,
+    prob_init_pres = 9.45796543536632e-06,
+    loglik = -75.9935681347126,
+    df = 6L,
+    conv = 0L
+  )
 
   utils::data(Galapagos_datalist)
   invisible(capture.output(


### PR DESCRIPTION
Fixed the way the likelihood code handles the continental sampling parameter (probability of initial presence) to ensure that it is optimised correctly.